### PR TITLE
fix: install rust in gateway docker image

### DIFF
--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: cd gateway
       - name: Build Gateway
-        run: docker build .
+        run: |
+          cd gateway
+          docker build .

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -1,0 +1,17 @@
+name: Build Gateway
+on:
+  push:
+    branches:
+      - main
+      - staging
+      - trying
+  pull_request:
+
+jobs:
+  build-gateway:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cd gateway
+      - name: Build Gateway
+        run: docker build .

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:latest as release
+FROM elixir:alpine as release
 
 WORKDIR /
 COPY . .
@@ -6,6 +6,9 @@ COPY . .
 # required for mix release deps
 RUN mix local.hex --force
 RUN mix local.rebar --force
+# required for auth module
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 # release a production version
 ENV MIX_ENV=prod
 RUN mix deps.get
@@ -13,7 +16,7 @@ RUN mix deps.compile
 RUN mix release stack
 
 # recopy to open new build files
-FROM elixir:latest
+FROM elixir:alpine
 
 COPY --from=release /_build/prod/rel/stack .
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,8 +9,8 @@ RUN apk add curl
 RUN mix local.hex --force
 RUN mix local.rebar --force
 # required for auth module
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain x86_64-unknown-linux-gnu
-ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable-x86_64-unknown-linux-gnu
+ENV PATH="$HOME/.cargo/bin:${PATH}"
 # release a production version
 ENV MIX_ENV=prod
 RUN mix deps.get

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add curl
 RUN mix local.hex --force
 RUN mix local.rebar --force
 # required for auth module
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable-x86_64-unknown-linux-gnu
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable-x86_64-unknown-linux-gnu
 ENV PATH="/root/.cargo/bin:${PATH}"
 # release a production version
 ENV MIX_ENV=prod

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,6 +3,9 @@ FROM elixir:slim as release
 WORKDIR /
 COPY . .
 
+RUN apt update && apt upgrade
+RUN apt install curl
+
 # required for mix release deps
 RUN mix local.hex --force
 RUN mix local.rebar --force

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /
 COPY . .
 
 RUN apt update && apt upgrade
-RUN apt install -y curl
+RUN apt install -y curl build-essential
 
 # required for mix release deps
 RUN mix local.hex --force

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add curl
 RUN mix local.hex --force
 RUN mix local.rebar --force
 # required for auth module
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable-x86_64-unknown-linux-gnu
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain x86_64-unknown-linux-gnu
 ENV PATH="/root/.cargo/bin:${PATH}"
 # release a production version
 ENV MIX_ENV=prod

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,7 +3,7 @@ FROM elixir:alpine as release
 WORKDIR /
 COPY . .
 
-apk add curl
+RUN apk add curl
 
 # required for mix release deps
 RUN mix local.hex --force

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /
 COPY . .
 
 RUN apt update && apt upgrade
-RUN apt install curl
+RUN apt install -y curl
 
 # required for mix release deps
 RUN mix local.hex --force

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -10,7 +10,7 @@ RUN mix local.hex --force
 RUN mix local.rebar --force
 # required for auth module
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="$HOME/.cargo/bin:${PATH}"
+ENV PATH="/root/.cargo/bin:${PATH}"
 # release a production version
 ENV MIX_ENV=prod
 RUN mix deps.get

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add curl
 RUN mix local.hex --force
 RUN mix local.rebar --force
 # required for auth module
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable-x86_64-unknown-linux-gnu
 ENV PATH="/root/.cargo/bin:${PATH}"
 # release a production version
 ENV MIX_ENV=prod

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,9 +1,7 @@
-FROM elixir:alpine as release
+FROM elixir:slim-buster as release
 
 WORKDIR /
 COPY . .
-
-RUN apk add curl
 
 # required for mix release deps
 RUN mix local.hex --force
@@ -18,7 +16,7 @@ RUN mix deps.compile
 RUN mix release stack
 
 # recopy to open new build files
-FROM elixir:alpine
+FROM elixir:slim-buster
 
 COPY --from=release /_build/prod/rel/stack .
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,6 +3,8 @@ FROM elixir:alpine as release
 WORKDIR /
 COPY . .
 
+apk add curl
+
 # required for mix release deps
 RUN mix local.hex --force
 RUN mix local.rebar --force

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add curl
 RUN mix local.hex --force
 RUN mix local.rebar --force
 # required for auth module
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable-x86_64-unknown-linux-gnu
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="$HOME/.cargo/bin:${PATH}"
 # release a production version
 ENV MIX_ENV=prod

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:slim-buster as release
+FROM elixir:slim as release
 
 WORKDIR /
 COPY . .
@@ -16,7 +16,7 @@ RUN mix deps.compile
 RUN mix release stack
 
 # recopy to open new build files
-FROM elixir:slim-buster
+FROM elixir:slim
 
 COPY --from=release /_build/prod/rel/stack .
 


### PR DESCRIPTION
## Described

Fix an issue with the docker image not having the Rust toolchain.

## Modules

<!-- Which of the following modules are modified -->

- [ ] API
- [x] Gateway
- [ ] Gateway (NIF)
- [ ] Frontend
  - [ ] Website

## Checklist

- [ ] I have formatted the modified files
- [ ] Changes the documentation
- [ ] Is a breaking change
- [ ] Adds custom CSS
- [ ] Rewrites a portion of the code
- [ ] Implements a feature
- [x] Fixes issue <!--#ISSUE_NUMBER-->
- [ ] Depends on <!--#PULL_REQUEST_NUMBER-->
- [x] Not a code change
- [ ] Code has been thoroughly tested
