### PR TITLE
fix: negative snowflakes

### DIFF
--- a/mineral/src/identity.rs
+++ b/mineral/src/identity.rs
@@ -13,11 +13,18 @@ lazy_static! {
 }
 
 // NOTE: these aren't public since these will eventually get replaced once Derailed gets distributed
-static DATACENTER_ID: i64 = 0;
+static DATACENTER_ID: i64 = 1;
 
 fn curtime() -> i64 {
     match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
         Ok(n) => n.as_secs() as i64,
+        Err(_) => panic!("SystemTime before UNIX EPOCH!"),
+    }
+}
+
+fn mcurtime() -> i64 {
+    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(n) => n.as_millis() as i64,
         Err(_) => panic!("SystemTime before UNIX EPOCH!"),
     }
 }
@@ -47,7 +54,7 @@ impl Snowflake {
     }
 
     fn get_time(&self) -> i64 {
-        time::OffsetDateTime::now_utc().unix_timestamp() - DERAILED_EPOCH
+        mcurtime() - DERAILED_EPOCH
     }
 
     fn fall(&mut self) -> i64 {
@@ -60,6 +67,7 @@ impl Snowflake {
 }
 
 
+// TODO: locks bad >:(
 pub async fn make_snowflake() -> i64 {
     SF.lock().await.fall()
 }

--- a/mineral/src/lib.rs
+++ b/mineral/src/lib.rs
@@ -11,3 +11,14 @@ pub use conn::{acquire, DB};
 pub use identity::{make_bucket, make_buckets, make_invite_id, make_snowflake};
 pub use models::*;
 pub use sqlx;
+
+#[cfg(test)]
+mod tests {
+    use super::make_snowflake;
+
+    #[tokio::test]
+    async fn sf_test() {
+        let sf = make_snowflake().await;
+        assert!(sf > 0);
+    }
+}


### PR DESCRIPTION
This *actually* fixes snowflake production. The details is basically:

- The Derailed Epoch is in *milliseconds*
- The numbers we were getting was in *seconds*

Yes, easy fix, but I am very dumb and couldn't tell this, but also didn't debug for some reason.