### PR TITLE
[hazel] `createSnowflake` is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 \target
 .env
 node_modules
+package-lock.json

--- a/hazel/app/register/page.tsx
+++ b/hazel/app/register/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { db, getToken } from "~/database";
 import { userSettings, users } from "~/schema";
+import { createSnowflake } from "~/snowflake";
 import argon2 from "argon2";
 
 import { registerForm } from "~/zschema";

--- a/hazel/lib/snowflake.ts
+++ b/hazel/lib/snowflake.ts
@@ -1,6 +1,6 @@
 var incr: number = 0;
 
-function createSnowflake(): number {
+export function createSnowflake(): number {
   const currentMs = Date.now();
 
   var epoch = (currentMs - 1704067200000) << 22;


### PR DESCRIPTION
Added import for the `createSnowflake` function in hazel `/register` as it was missing raising an exception.